### PR TITLE
Add Docker build and dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+FROM rust:bookworm
+
+# Install base utils
+RUN apt-get update
+RUN apt-get install -y \
+  curl \
+  psmisc
+
+# Install Deno
+ENV DENO_INSTALL=/usr/local/deno
+ENV PATH="$PATH:$DENO_INSTALL/bin"
+RUN curl -fsSL https://deno.land/install.sh | sh
+
+# Install Tauri v2 dependencies
+# https://v2.tauri.app/start/prerequisites/#linux
+RUN apt-get install -y libwebkit2gtk-4.1-dev \
+  build-essential \
+  wget \
+  file \
+  libxdo-dev \
+  libssl-dev \
+  libayatana-appindicator3-dev \
+  librsvg2-dev
+
+# Install Deno dependencies
+RUN apt-get install -y protobuf-compiler \
+  clang \
+  xdg-utils
+
+# NOTE(sasetz): linuxdeploy doesn't work, probably won't work and we don't
+# really need it. Just in case, leaving this here
+
+# # Install linuxdeploy (no FUSE mode)
+# RUN wget -O /tmp/linuxdeploy-x86_64.AppImage \
+#       https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage && \
+#     chmod +x /tmp/linuxdeploy-x86_64.AppImage && \
+#     /tmp/linuxdeploy-x86_64.AppImage --appimage-extract && \
+#     mv squashfs-root /opt/linuxdeploy && \
+#     ln -s /opt/linuxdeploy/AppRun /usr/local/bin/linuxdeploy && \
+#     rm /tmp/linuxdeploy-x86_64.AppImage
+#
+# # Install appimage plugin the same way (optional but recommended)
+# RUN wget -O /tmp/linuxdeploy-plugin-appimage-x86_64.AppImage \
+#       https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage && \
+#     chmod +x /tmp/linuxdeploy-plugin-appimage-x86_64.AppImage && \
+#     /tmp/linuxdeploy-plugin-appimage-x86_64.AppImage --appimage-extract && \
+#     mv squashfs-root /opt/linuxdeploy-plugin-appimage && \
+#     ln -s /opt/linuxdeploy-plugin-appimage/AppRun /usr/local/bin/linuxdeploy-plugin-appimage && \
+#     rm /tmp/linuxdeploy-plugin-appimage-x86_64.AppImage
+
+WORKDIR /app
+
+CMD ["deno", "task", "dev"]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+tasks:
+  release:
+    desc: Build release binary for Linux
+    cmds:
+      - docker run -v ".:/app" tauri-test:latest deno task tauri build
+  dev:
+    desc: Serve frontend to debug build
+    cmds:
+      - docker compose up -d
+  build:
+    desc: Build debug binary (this should fail at the last stage)
+    cmds:
+      - docker run -v ".:/app" tauri-test:latest deno task tauri dev --no-dev-server-wait --no-watch --no-dev-server

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,13 @@
+services:
+  tauri-builder:
+    image: tauri-test:latest
+    container_name: tauri-test
+    working_dir: /app
+    user: "${UID}:${GID}"
+    volumes:
+      - .:/app
+    ports:
+      - "1420:1420"
+      - "1421:1421"
+    command: deno task dev
+

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "identifier": "com.example.openrisk",
   "build": {
-    "beforeDevCommand": "deno task dev",
+    "beforeDevCommand": "",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "deno task build",
     "frontendDist": "../dist"
@@ -23,7 +23,8 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": "app",
+    "useLocalToolsDir": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig(async () => ({
   server: {
     port: 1420,
     strictPort: true,
-    host: host || false,
+    host: host || "0.0.0.0",
     hmr: host
       ? {
           protocol: "ws",


### PR DESCRIPTION
This will make even the regular builds produce only executable (no AppImage, no .deb, .rpm, etc.) and the `deno task tauri dev` will no longer start serving the frontend. To fix both of these, consider reverting `src-tauri/tauri.conf.json`