### PR TITLE
Render relative close associates in person cards

### DIFF
--- a/src/components/data-model/EntityInlineDetail.tsx
+++ b/src/components/data-model/EntityInlineDetail.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import type { DataModelEntity, TypedValue } from "@/core/data-model/types";
 import { EntityCardFooter } from "./EntityCardFooter";
+import { RelativeCloseAssociatesField } from "./RelativeCloseAssociatesField";
 import { TypedValueView } from "./TypedValueView";
 
 // ── helpers ────────────────────────────────────────────────────────────────
@@ -64,6 +65,7 @@ export function PersonEntityInline({ entity }: { entity: DataModelEntity }) {
     const addresses = propList(entity, "addresses");
     const emails = propList(entity, "emails");
     const phones = propList(entity, "phones");
+    const relativeCloseAssociates = propList(entity, "relativeCloseAssociates");
     const notes = firstProp(entity, "notes");
     const pepStatus = firstProp(entity, "pepStatus");
     const sanctioned = firstProp(entity, "sanctioned");
@@ -107,6 +109,7 @@ export function PersonEntityInline({ entity }: { entity: DataModelEntity }) {
             <TagField label="Addresses" values={addresses} />
             <TagField label="Emails" values={emails} />
             <TagField label="Phones" values={phones} />
+            <RelativeCloseAssociatesField values={relativeCloseAssociates} />
 
             {notesText && (
                 <p className="text-sm text-muted-foreground italic border-l-2 border-border pl-3">{notesText}</p>
@@ -115,7 +118,8 @@ export function PersonEntityInline({ entity }: { entity: DataModelEntity }) {
             <EntityCardFooter
                 entity={entity}
                 excludePropKeys={["name", "notes", "aliases", "birthDate", "birthPlace",
-                    "nationalities", "addresses", "emails", "phones", "pepStatus", "sanctioned"]}
+                    "nationalities", "addresses", "emails", "phones", "relativeCloseAssociates",
+                    "pepStatus", "sanctioned"]}
             />
         </div>
     );
@@ -195,4 +199,3 @@ export function OrganizationInline({ entity }: { entity: DataModelEntity }) {
         </div>
     );
 }
-

--- a/src/components/data-model/PersonEntityCard.tsx
+++ b/src/components/data-model/PersonEntityCard.tsx
@@ -8,6 +8,7 @@ import {
 import type { DataModelEntity, TypedValue } from "@/core/data-model/types";
 import { EntityCardFooter } from "./EntityCardFooter";
 import { EntityTypeBadge } from "./EntityTypeBadge";
+import { RelativeCloseAssociatesField } from "./RelativeCloseAssociatesField";
 import { TypedValueView } from "./TypedValueView";
 
 interface PersonEntityCardProps {
@@ -42,6 +43,7 @@ export function PersonEntityCard({ entity }: PersonEntityCardProps) {
     const addresses = propList(entity, "addresses");
     const emails = propList(entity, "emails");
     const phones = propList(entity, "phones");
+    const relativeCloseAssociates = propList(entity, "relativeCloseAssociates");
 
     const pepStatus = firstProp(entity, "pepStatus");
     const sanctioned = firstProp(entity, "sanctioned");
@@ -99,6 +101,7 @@ export function PersonEntityCard({ entity }: PersonEntityCardProps) {
                 <TagField label="Addresses" values={addresses} />
                 <TagField label="Emails" values={emails} />
                 <TagField label="Phones" values={phones} />
+                <RelativeCloseAssociatesField values={relativeCloseAssociates} />
 
                 {notesText && (
                     <p className="text-sm text-muted-foreground italic border-l-2 border-border pl-3">
@@ -119,6 +122,7 @@ export function PersonEntityCard({ entity }: PersonEntityCardProps) {
                         "addresses",
                         "emails",
                         "phones",
+                        "relativeCloseAssociates",
                         "pepStatus",
                         "sanctioned",
                     ]}

--- a/src/components/data-model/RelativeCloseAssociateValue.tsx
+++ b/src/components/data-model/RelativeCloseAssociateValue.tsx
@@ -1,0 +1,50 @@
+import { Badge } from "@/components/ui/badge";
+
+interface RelativeCloseAssociate {
+    name: string;
+    relation?: string;
+}
+
+function parseRelativeCloseAssociate(value: unknown): RelativeCloseAssociate | null {
+    if (!value || typeof value !== "object") {
+        return null;
+    }
+
+    const candidate = value as Record<string, unknown>;
+    const name = typeof candidate.name === "string" ? candidate.name.trim() : "";
+    const relation = typeof candidate.relation === "string" ? candidate.relation.trim() : "";
+
+    if (!name) {
+        return null;
+    }
+
+    return relation ? { name, relation } : { name };
+}
+
+export function relativeCloseAssociateCompactText(value: unknown): string {
+    const parsed = parseRelativeCloseAssociate(value);
+    if (!parsed) {
+        return "";
+    }
+
+    return parsed.relation ? `${parsed.name} - ${parsed.relation}` : parsed.name;
+}
+
+export function RelativeCloseAssociateValue({ value }: { value: unknown }) {
+    const parsed = parseRelativeCloseAssociate(value);
+
+    if (!parsed) {
+        return null;
+    }
+
+    return (
+        <span className="inline-flex max-w-full flex-wrap items-center gap-2">
+            <span className="break-words">{parsed.name}</span>
+            {parsed.relation && (
+                <Badge variant="outline" className="text-xs font-normal">
+                    {parsed.relation}
+                </Badge>
+            )}
+        </span>
+    );
+}

--- a/src/components/data-model/RelativeCloseAssociatesField.tsx
+++ b/src/components/data-model/RelativeCloseAssociatesField.tsx
@@ -1,0 +1,32 @@
+import type { TypedValue } from "@/core/data-model/types";
+import { TypedValueView } from "./TypedValueView";
+
+function hasDisplayValue(value: TypedValue): boolean {
+    if (value.value === null || value.value === undefined) return false;
+    if (typeof value.value === "string" && value.value.trim() === "") return false;
+    return true;
+}
+
+export function RelativeCloseAssociatesField({ values }: { values: TypedValue[] }) {
+    const displayValues = values.filter(hasDisplayValue);
+
+    if (!displayValues.length) {
+        return null;
+    }
+
+    return (
+        <div className="space-y-2">
+            <p className="text-xs uppercase text-muted-foreground">Relatives and Close Associates</p>
+            <div className="grid gap-2 sm:grid-cols-2">
+                {displayValues.map((value, index) => (
+                    <div
+                        key={`relative-close-associate-${index}`}
+                        className="rounded-md border border-border/70 px-3 py-2 text-sm"
+                    >
+                        <TypedValueView item={value} />
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/components/data-model/TypedValueView.tsx
+++ b/src/components/data-model/TypedValueView.tsx
@@ -1,6 +1,7 @@
 import type { TypedValue } from "@/core/data-model/types";
 import { ExternalLink } from "@/components/ui/ExternalLink";
 import { RegistryJurisdictionValue } from "./RegistryJurisdictionValue";
+import { RelativeCloseAssociateValue } from "./RelativeCloseAssociateValue";
 
 interface TypedValueViewProps {
     item: TypedValue | undefined;
@@ -42,6 +43,10 @@ export function TypedValueView({ item }: TypedValueViewProps) {
 
     if (item.$type === "registry-jurisdiction-code" && typeof item.value === "string") {
         return <RegistryJurisdictionValue code={item.value} />;
+    }
+
+    if (item.$type === "relative-close-associate") {
+        return <RelativeCloseAssociateValue value={item.value} />;
     }
 
     if (typeof item.value === "object") {

--- a/src/components/data-model/entityProps.ts
+++ b/src/components/data-model/entityProps.ts
@@ -1,5 +1,6 @@
 import type { DataModelEntity, TypedValue } from "@/core/data-model/types";
 import { registryJurisdictionCompactText } from "./RegistryJurisdictionValue";
+import { relativeCloseAssociateCompactText } from "./RelativeCloseAssociateValue";
 
 export function hasDisplayValue(value: TypedValue | undefined): boolean {
     if (!value) return false;
@@ -50,6 +51,10 @@ export function typedValueToCompactText(value: TypedValue | undefined): string {
 
     if (value.$type === "registry-jurisdiction-code" && typeof rawValue === "string") {
         return registryJurisdictionCompactText(rawValue);
+    }
+
+    if (value.$type === "relative-close-associate") {
+        return relativeCloseAssociateCompactText(rawValue);
     }
 
     if (typeof rawValue === "object") {

--- a/src/components/data-model/entityTableConfigs.ts
+++ b/src/components/data-model/entityTableConfigs.ts
@@ -79,6 +79,7 @@ export const ORGANIZATION_TABLE_COLUMNS: EntityTableColumnConfig[] = [
 const SKIP_PROPS = new Set([
     "name", "aliases", "alias", // name always first; aliases shown as secondary text
     "notes", "description", "remarks", "summary", // too long
+    "relativeCloseAssociates", // shown only in person cards/details
     "pepStatus", "sanctioned", // shown as badges in expanded view
     "id", "uuid", "sourceId", "externalId", // raw IDs, not useful in column
 ]);
@@ -106,6 +107,7 @@ const PROP_LABELS: Record<string, string> = {
     phone: "Phone",
     email: "Email",
     website: "Website",
+    relativeCloseAssociates: "RCA",
     position: "Position",
     employer: "Employer",
 };
@@ -175,4 +177,3 @@ export function buildDynamicColumns(
 
     return [nameCol, ...extraCols];
 }
-


### PR DESCRIPTION
## Summary
- add frontend rendering for `relative-close-associate` typed values
- show relatives and close associates in person cards/details
- skip `relativeCloseAssociates` in dynamic table columns

## Validation
- `npm run build`
- `git diff --check`
